### PR TITLE
Use named exports exports, simplifying index.js

### DIFF
--- a/src/collapse.js
+++ b/src/collapse.js
@@ -1,7 +1,7 @@
 import zip from "./utils/zip";
 
-const collapse = (strs, ...args) =>
-  zip(strs, ...args)
+export function collapse(strs, ...args) {
+  return zip(strs, ...args)
     .map(str => {
       return str
         .split("\n")
@@ -12,5 +12,4 @@ const collapse = (strs, ...args) =>
         .join(" ");
     })
     .join("");
-
-export default collapse;
+}

--- a/src/deindent.js
+++ b/src/deindent.js
@@ -1,6 +1,6 @@
 import zip from "./utils/zip";
 
-const deindent = (strs, ...args) => {
+export function deindent(strs, ...args) {
   const str = zip(strs, ...args).join("");
 
   const lines = str.split("\n");
@@ -41,6 +41,4 @@ const deindent = (strs, ...args) => {
       return strs;
     }, [])
     .join("\n");
-};
-
-export default deindent;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,4 @@
-import _deindent from "./deindent";
-export const deindent = _deindent;
-
-import _collapse from "./collapse";
-export const collapse = _collapse;
-
-import _reflow from "./reflow";
-export const reflow = _reflow;
-
-import _qw from "./qw";
-export const qw = _qw;
+export * from "./deindent";
+export * from "./collapse";
+export * from "./reflow";
+export * from "./qw";

--- a/src/qw.js
+++ b/src/qw.js
@@ -1,6 +1,6 @@
 import zip from "./utils/zip";
 
-export default function qw(strs, ...args) {
+export function qw(strs, ...args) {
   return zip(strs, ...args)
     .join("")
     .split(/\s+/)

--- a/src/reflow.js
+++ b/src/reflow.js
@@ -96,9 +96,9 @@ function wrapTextToWidth(str, maximumWidth) {
   return wrappedParagraphs.join("\n\n");
 }
 
-import deindent from "./deindent";
+import { deindent } from "./deindent";
 
-export default function reflow(str, width) {
+export function reflow(str, width) {
   if (typeof width === "undefined") {
     width = str;
     str = undefined;

--- a/test/collapse.spec.js
+++ b/test/collapse.spec.js
@@ -1,5 +1,5 @@
 import expect from "unexpected";
-import collapse from "../src/collapse";
+import { collapse } from "../src/collapse";
 
 describe("collapse", () => {
   it("should collapse whitespace at the beginning and end of a string", () => {

--- a/test/deindent.spec.js
+++ b/test/deindent.spec.js
@@ -1,5 +1,5 @@
 import expect from "unexpected";
-import deindent from "../src/deindent";
+import { deindent } from "../src/deindent";
 
 describe("deindent", () => {
   it("should be a function", () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,7 @@ import expect from "unexpected";
 import { readdirSync } from "fs";
 import { resolve, basename } from "path";
 import * as stringUtils from "../src/index";
-import deindent from "../src/deindent";
+import { deindent } from "../src/deindent";
 
 describe("main module export", () => {
   it("should export the deindent method", () => {

--- a/test/qw.spec.js
+++ b/test/qw.spec.js
@@ -1,5 +1,5 @@
 import expect from "unexpected";
-import qw from "../src/qw";
+import { qw } from "../src/qw";
 
 describe("qw", () => {
   it("should split a string into an array of words", () => {

--- a/test/reflow.spec.js
+++ b/test/reflow.spec.js
@@ -1,6 +1,6 @@
 import expect from "unexpected";
-import deindent from "../src/deindent";
-import reflow from "../src/reflow";
+import { deindent } from "../src/deindent";
+import { reflow } from "../src/reflow";
 
 describe("reflow", () => {
   it("should wrap lines to fit", () => {


### PR DESCRIPTION
I'm not too familiar with ESM yet, so I'm not sure if default exports are somehow better than named ones -- but it seems like src/index.js can be simplified by using named exports :)