### PR TITLE
Handle string interpolation when it falls on line end

### DIFF
--- a/src/collapse.js
+++ b/src/collapse.js
@@ -1,15 +1,16 @@
 import zip from "./utils/zip";
 
 export default function collapse(strs, ...args) {
-  return zip(strs, ...args)
-    .map(str => {
-      return str
-        .split("\n")
-        .map(line => {
-          return line.replace(/^\s+/, "").replace(/\s+$/, "");
-        })
-        .filter(str => str.length > 0)
-        .join(" ");
-    })
-    .join("");
+  return (
+    zip(strs, ...args)
+      // get the full string
+      .join("")
+      // do a multiline trim
+      .replace(/^\s+/gm, "")
+      .replace(/\s+$/gm, "")
+      // join the lines, compatible with collapse
+      .replace(/\n/g, " ")
+      // trim the dangling line ends
+      .trim()
+  );
 }

--- a/src/collapse.js
+++ b/src/collapse.js
@@ -1,16 +1,8 @@
 import zip from "./utils/zip";
 
 export default function collapse(strs, ...args) {
-  return (
-    zip(strs, ...args)
-      // get the full string
-      .join("")
-      // do a multiline trim
-      .replace(/^\s+/gm, "")
-      .replace(/\s+$/gm, "")
-      // join the lines, compatible with collapse
-      .replace(/\n/g, " ")
-      // trim the dangling line ends
-      .trim()
-  );
+  return zip(strs, ...args)
+    .join("")
+    .replace(/(^\s+|\s+$)/gm, "")
+    .replace(/\n/g, " ");
 }

--- a/test/collapse.spec.js
+++ b/test/collapse.spec.js
@@ -68,4 +68,17 @@ describe("collapse", () => {
       `This is the first placeholder: foo Also, another placeholder: bar Also this, it should be on the next line: And it does`
     );
   });
+
+  it("should collapse spaces at the end of lines", () => {
+    const EMPTY = "";
+
+    expect(
+      collapse`
+      Foo ${EMPTY}
+      Bar
+    `,
+      "to equal",
+      "Foo Bar"
+    );
+  });
 });

--- a/test/collapse.spec.js
+++ b/test/collapse.spec.js
@@ -40,4 +40,32 @@ describe("collapse", () => {
         `"foo" and another placeholder which value is "bar".`
     );
   });
+
+  it("should work seamlessy when placeholders fall on line ends", () => {
+    const p1 = "foo";
+    const p2 = "bar";
+
+    expect(
+      collapse`
+      This is the first placeholder:
+      ${p1}
+      Also, another placeholder:
+      ${p2}
+      Also this, it should be on the next line:
+      And it does
+    `,
+      "to equal",
+      collapse`
+      This is the first placeholder:
+      foo
+      Also, another placeholder:
+      bar
+      Also this, it should be on the next line:
+      And it does
+    `
+    ).and(
+      "to equal",
+      `This is the first placeholder: foo Also, another placeholder: bar Also this, it should be on the next line: And it does`
+    );
+  });
 });


### PR DESCRIPTION
This PR addresses an issue happening when template arguments  are falling at the end of the line.

The current product of the `zip()`  function includes a list of chunks + arguments that when joined with empty spaces skips the transformation of any new line subsequent to arguments into spaces.

This is adding two new test cases and a rework of the collapse function so that it joins the product of zip before doing any other transformation.