### PR TITLE
deindent: Don't break with the empty string

### DIFF
--- a/src/deindent.js
+++ b/src/deindent.js
@@ -10,7 +10,10 @@ export default function deindent(strs, ...args) {
   let processedIndex = 0;
   let indentationOfFirstLine = null;
 
-  while (typeof indentationOfFirstLine !== "number" && processedIndex < lines.length) {
+  while (
+    typeof indentationOfFirstLine !== "number" &&
+    processedIndex < lines.length
+  ) {
     let firstLineCandidate = lines[processedIndex];
 
     // If the line has non-whitespace content

--- a/src/deindent.js
+++ b/src/deindent.js
@@ -10,7 +10,7 @@ export default function deindent(strs, ...args) {
   let processedIndex = 0;
   let indentationOfFirstLine = null;
 
-  while (typeof indentationOfFirstLine !== "number") {
+  while (typeof indentationOfFirstLine !== "number" && processedIndex < lines.length) {
     let firstLineCandidate = lines[processedIndex];
 
     // If the line has non-whitespace content

--- a/test/deindent.spec.js
+++ b/test/deindent.spec.js
@@ -71,6 +71,12 @@ describe("deindent", () => {
     expect(str, "to equal", "foo\n      bar");
   });
 
+  it("should not break with an empty string", () => {
+    const str = deindent``;
+
+    expect(str, "to equal", "");
+  });
+
   it("should work with variables", () => {
     const placeholder = "FOO BAR";
     const str = deindent`


### PR DESCRIPTION
Currently ``` deindent`` ``` fails with:

```
TypeError: Cannot read property 'trim' of undefined
  at deindent (src/deindent.js:17:28)
```